### PR TITLE
Fix potential fatal errors in quick info

### DIFF
--- a/updatecheck.php
+++ b/updatecheck.php
@@ -73,7 +73,7 @@ function hi_updateQuickInfo() {
     try {
         $localVersion = hi_versionInfo($_POST['versionstr']);
     } catch (RuntimeException $ex) {
-        $localVersion = null;
+        return;
     }
     if (count($localVersion) !== 7) {
         return;
@@ -83,7 +83,7 @@ function hi_updateQuickInfo() {
         $versionStr = hi_fsFileGetContents(trim($localVersion[6]), $timeout);
         $remoteVersion = hi_versionInfo($versionStr);
     } catch (RuntimeException $ex) {
-        $versionStr = $remoteVersion = null;
+        return;
     }
     if (count($remoteVersion) !== 7) {
         return;


### PR DESCRIPTION
If a `RuntimeException` is thrown, we set `$localVersion` and `$remoteVersion` to null, respectively.  Immediately afterwards we call `count()` on the variable, and throws a `TypeError` as of PHP 8.0.0.

We avoid that by returning immediately from `hi_updateQuickInfo()` on failure.